### PR TITLE
Remove Hubot dependency

### DIFF
--- a/external-scripts.json
+++ b/external-scripts.json
@@ -1,3 +1,0 @@
-[
-  "hubot-shipit"
-]

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "contributors:generate": "all-contributors generate"
   },
   "dependencies": {
-    "hubot-shipit": "~0.2.0"
+    
   },
   "devDependencies": {
     "all-contributors-cli": "^4.10.1"


### PR DESCRIPTION
I removed the hubot dependency and deleted the external-scripts.json file because there was no use for it without a hubot. 